### PR TITLE
fix(make the crate compatible with rust ^1.31.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-daemonize"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-daemonize"
 documentation = "https://docs.rs/parity-daemonize"

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -8,7 +8,7 @@ mod linux;
 mod unsupported;
 
 #[cfg(target_os = "linux")]
-pub use linux::*;
+pub use self::linux::*;
 
 #[cfg(not(target_os = "linux"))]
-pub use unsupported::*;
+pub use self::unsupported::*;


### PR DESCRIPTION
```bash
➜  parity-daemonize git:(master) ✗ rustc --version
rustc 1.31.0 (abe02cefd 2018-12-04)
➜  parity-daemonize git:(make-rust-v1.31.0-compatible) ✗ cargo build                             
   Compiling rustc-demangle v0.1.13                                                                                                                                                                         
   Compiling cfg-if v0.1.6                                                                                                                                                                                  
   Compiling slab v0.4.2                                                                                                                                                                                    
   Compiling lazycell v1.2.1                                                                                                                                                                                
   Compiling ansi_term v0.11.0                                                                                                                                                                              
   Compiling libc v0.2.48                                                                                                                                                                                   
   Compiling log v0.4.6                                                                                                                                                                                     
   Compiling backtrace-sys v0.1.28                                                                                                                                                                          
   Compiling iovec v0.1.2                                                                                                                                                                                   
   Compiling net2 v0.2.33                                                                                                                                                                                   
   Compiling backtrace v0.3.13                                                                                                                                                                              
   Compiling mio v0.6.16                                                                                                                                                                                    
   Compiling failure v0.1.5                                                                                                                                                                                 
   Compiling parity-daemonize v0.2.1 (/home/niklasad1/Github/parity-daemonize)                                                                                                                              
    Finished dev [unoptimized + debuginfo] target(s) in 2.25s  
```