### PR TITLE
bump version 0.2.1 -> 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-daemonize"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 repository = "https://github.com/paritytech/parity-daemonize"
 documentation = "https://docs.rs/parity-daemonize"


### PR DESCRIPTION
I did faulty release technically #10 is breaking change but at the time I didn't realize it, see below

```bash
   --> parity/main.rs:238:4
    |
200 |     let handle = if let Some(ref pid) = conf.args.arg_daemon_pid_file {
    |                              ------- borrow of `conf.args.arg_daemon_pid_file.0` occurs here
...
238 |             conf,
    |             ^^^^ move out of `conf` occurs here

error[E0505]: cannot move out of `conf` because it is borrowed
   --> parity/main.rs:273:9
    |
200 |     let handle = if let Some(ref pid) = conf.args.arg_daemon_pid_file {
    |                              ------- borrow of `conf.args.arg_daemon_pid_file.0` occurs here
...
273 |         start(conf, logger, move |_| {}, move || {})
    |               ^^^^ move out of `conf` occurs here
```

I have to `cargo yank version 0.2.1`
