### PR TITLE
fix(corrupted pidfiles)

### DIFF
--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -85,7 +85,7 @@ pub fn daemonize<T: Into<PathBuf> + Sized>(pid_file: T) -> Result<Handle> {
 
 		// create the pid file
 		let pid_fd = map_err!(
-			open(path_c.as_ptr(), libc::O_WRONLY | libc::O_TRUNC | libc::O_CREAT, 0o666),
+			open(path_c.as_ptr(), libc::O_WRONLY | libc::O_TRUNC | libc::O_CREAT, 0o644),
 			ErrorKind::OpenPidfile(io::Error::last_os_error())
 		)?;
 

--- a/src/platform/linux.rs
+++ b/src/platform/linux.rs
@@ -85,7 +85,7 @@ pub fn daemonize<T: Into<PathBuf> + Sized>(pid_file: T) -> Result<Handle> {
 
 		// create the pid file
 		let pid_fd = map_err!(
-			open(path_c.as_ptr(), libc::O_WRONLY | libc::O_CREAT, 0o666),
+			open(path_c.as_ptr(), libc::O_WRONLY | libc::O_TRUNC | libc::O_CREAT, 0o666),
 			ErrorKind::OpenPidfile(io::Error::last_os_error())
 		)?;
 


### PR DESCRIPTION
Pidfiles were not being truncated before written to, so if the pidfile already existed and the new pid had less digits than the previous pid, the resulting pid would be incorrect. This would not have been caught by the test most of the time.

This PR also changes the file creation mode from 0666 to the more standard 0644.

Fixes openethereum/openethereum/issues/336
